### PR TITLE
M24H-67 use a delegate state to prevent double submissions in case of timeouts

### DIFF
--- a/go-app.js
+++ b/go-app.js
@@ -383,7 +383,7 @@ go.app = function() {
 
     });
 
-    self.states.add('Submit_Case', function(name) {
+    self.states.add('Submit_Case', function (name, opts) {
       return go.utils.generate_case_number(self.im, self.im.user.answers.Facility_Code_Entry)
         .then(function(case_number) {
           // Send response to Ona
@@ -425,15 +425,19 @@ go.app = function() {
             JSON.stringify(err.response)
           ].join(' '));
         })
-        .then(function() {
-          return new EndState(name, {
-            text: $("Thank you! Your report has been submitted. " +
-                    "You will receive an SMS with the patient name and " +
-                    "case number in the next hour."),
-            next: 'Facility_Code_Entry'
-          });
+        .then(function () {
+          return self.states.create('End', opts);
         });
+    });
 
+
+    self.states.add('End', function(name) {
+        return new EndState(name, {
+          text: $("Thank you! Your report has been submitted. " +
+                  "You will receive an SMS with the patient name and " +
+                  "case number in the next hour."),
+          next: 'Facility_Code_Entry'
+        });
     });
     // END NEW STEPS
 

--- a/src/app.js
+++ b/src/app.js
@@ -277,7 +277,7 @@ go.app = function() {
 
     });
 
-    self.states.add('Submit_Case', function(name) {
+    self.states.add('Submit_Case', function (name, opts) {
       return go.utils.generate_case_number(self.im, self.im.user.answers.Facility_Code_Entry)
         .then(function(case_number) {
           // Send response to Ona
@@ -319,15 +319,19 @@ go.app = function() {
             JSON.stringify(err.response)
           ].join(' '));
         })
-        .then(function() {
-          return new EndState(name, {
-            text: $("Thank you! Your report has been submitted. " +
-                    "You will receive an SMS with the patient name and " +
-                    "case number in the next hour."),
-            next: 'Facility_Code_Entry'
-          });
+        .then(function () {
+          return self.states.create('End', opts);
         });
+    });
 
+
+    self.states.add('End', function(name) {
+        return new EndState(name, {
+          text: $("Thank you! Your report has been submitted. " +
+                  "You will receive an SMS with the patient name and " +
+                  "case number in the next hour."),
+          next: 'Facility_Code_Entry'
+        });
     });
     // END NEW STEPS
 

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -423,8 +423,8 @@ describe("app", function() {
                     .setup.user.answers(completed_answers)
                     .input('1')
                     .check.interaction({
-                        state: 'Facility_Code_Entry',
-                        reply: /Welcome! To report a malaria case, please enter your facility code./
+                        state: 'End',
+                        reply: /Thank you! Your report has been submitted\./
                     })
                     .check(function (api) {
                         var http_sent = _.where(api.http.requests, {


### PR DESCRIPTION
When a USSD session timeouts or aborts, the state machine picks up at
the start of the state where it left off. That may, in certain
situations mean it'll do an API call twice.

Using a delegate state prevents that from happening.
