### PR TITLE
Make go-jsbox-ona a production dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "vumigo_v02": "~0.2",
     "q": "~0.9",
     "lodash": "~2.4.1",
-    "moment": "~2.11.2"
+    "moment": "~2.11.2",
+    "go-jsbox-ona": "~0.0.2"
   },
   "devDependencies": {
-    "go-jsbox-ona": "~0.0.2",
     "istanbul": "~0.3.19",
     "mocha": "~1.18",
     "jshint": "~2.4.4",


### PR DESCRIPTION
From the mc2 app:
`Error: Cannot find module 'go-jsbox-ona'`