### PR TITLE
Update ona version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "q": "~0.9",
     "lodash": "~2.4.1",
     "moment": "~2.11.2",
-    "go-jsbox-ona": "~0.0.2"
+    "go-jsbox-ona": "~0.1.1"
   },
   "devDependencies": {
     "istanbul": "~0.3.19",

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -466,7 +466,7 @@ describe("app", function() {
                     })
                     .check(function (api) {
                         var http_sent = _.where(api.http.requests, {
-                            url: 'http://ona.io/api/v1/submission'
+                            url: 'http://ona.io/api/v1/submissions'
                         })[0];
                         assert.deepEqual(http_sent.data, {
                             id: '1',
@@ -504,7 +504,7 @@ describe("app", function() {
                     })
                     .check(function (api) {
                         var http_sent = _.where(api.http.requests, {
-                            url: 'http://ona.io/api/v1/submission'
+                            url: 'http://ona.io/api/v1/submissions'
                         })[0];
                         assert.deepEqual(http_sent.data, {
                             id: '1',


### PR DESCRIPTION
I got this on QA `{"code":404,"request":{"url":"https://ona.io/api/v1/submission"`

It was fixed here https://github.com/praekelt/go-jsbox-ona/commit/69c4d218a6bdc96e051338733612baf759d3cc83 and included in the `0.1.1` release.