### PR TITLE
Downgrade raven install to the version used by ndoh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ RUN mv ./node_modules /usr/local/lib/
 # Copy in the app Javascript
 COPY go-*.js /app/
 
-RUN pip install raven==3.6.0
+RUN pip install raven==3.5.2


### PR DESCRIPTION
This version of Raven is still causing errors when trying to include Twisted things.